### PR TITLE
Fix caching for release notifications

### DIFF
--- a/.github/workflows/notify-starred-releases.yml
+++ b/.github/workflows/notify-starred-releases.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cache
-          key: ${{ runner.os }}-releases-cache
+          key: ${{ runner.os }}-releases-cache-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-releases-cache
+            ${{ runner.os }}-releases-cache-
       
       - name: List starred repos
         id: star


### PR DESCRIPTION
## Summary
- ensure workflow cache updates on each run by adding run_id to the key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a9ab9e218832883a1f4651e24bcdb